### PR TITLE
Expose inner properties via extension methods

### DIFF
--- a/HAPCompact/HAPCompact.csproj
+++ b/HAPCompact/HAPCompact.csproj
@@ -66,6 +66,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -89,6 +92,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeType.cs">
       <Link>HtmlNodeType.cs</Link>

--- a/HAPLight/HAPLight.5.0.csproj
+++ b/HAPLight/HAPLight.5.0.csproj
@@ -73,6 +73,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -102,6 +105,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeNavigator.cs">
       <Link>HtmlNodeNavigator.cs</Link>

--- a/HAPLight/HAPLight.csproj
+++ b/HAPLight/HAPLight.csproj
@@ -68,6 +68,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -97,6 +100,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeNavigator.cs">
       <Link>HtmlNodeNavigator.cs</Link>

--- a/HAPPhone.7.1/HAPPhone.7.1.csproj
+++ b/HAPPhone.7.1/HAPPhone.7.1.csproj
@@ -66,6 +66,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -95,6 +98,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeNavigator.cs">
       <Link>HtmlNodeNavigator.cs</Link>

--- a/HAPPhone/HAPPhone.csproj
+++ b/HAPPhone/HAPPhone.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -87,6 +90,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeType.cs">
       <Link>HtmlNodeType.cs</Link>

--- a/HAPPortable/HAPPortable.csproj
+++ b/HAPPortable/HAPPortable.csproj
@@ -48,6 +48,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -68,6 +71,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeType.cs">
       <Link>HtmlNodeType.cs</Link>

--- a/HtmlAgilityPack.Metro/HtmlAgilityPack.Metro.csproj
+++ b/HtmlAgilityPack.Metro/HtmlAgilityPack.Metro.csproj
@@ -58,6 +58,9 @@
     <Compile Include="..\HtmlAgilityPack\HtmlAttributeCollection.cs">
       <Link>HtmlAttributeCollection.cs</Link>
     </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlAttributeExtensions.cs">
+      <Link>HtmlAttributeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlCommentNode.cs">
       <Link>HtmlCommentNode.cs</Link>
     </Compile>
@@ -78,6 +81,9 @@
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeCollection.cs">
       <Link>HtmlNodeCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\HtmlAgilityPack\HtmlNodeExtensions.cs">
+      <Link>HtmlNodeExtensions.cs</Link>
     </Compile>
     <Compile Include="..\HtmlAgilityPack\HtmlNodeType.cs">
       <Link>HtmlNodeType.cs</Link>

--- a/HtmlAgilityPack/HtmlAgilityPack VS2008.csproj
+++ b/HtmlAgilityPack/HtmlAgilityPack VS2008.csproj
@@ -47,11 +47,13 @@
   <ItemGroup>
     <Compile Include="EncodingFoundException.cs" />
     <Compile Include="HtmlAttributeCollection.cs" />
+    <Compile Include="HtmlAttributeExtensions.cs" />
     <Compile Include="HtmlCommentNode.cs" />
     <Compile Include="HtmlConsoleListener.cs" />
     <Compile Include="HtmlElementFlag.cs" />
     <Compile Include="HtmlNameTable.cs" />
     <Compile Include="HtmlNodeCollection.cs" />
+    <Compile Include="HtmlNodeExtensions.cs" />
     <Compile Include="HtmlNodeType.cs" />
     <Compile Include="HtmlParseError.cs" />
     <Compile Include="HtmlParseErrorCode.cs" />

--- a/HtmlAgilityPack/HtmlAgilityPack.csproj
+++ b/HtmlAgilityPack/HtmlAgilityPack.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="EncodingFoundException.cs" />
     <Compile Include="HtmlAttributeCollection.cs" />
+    <Compile Include="HtmlAttributeExtensions.cs" />
     <Compile Include="HtmlCommentNode.cs" />
     <Compile Include="HtmlConsoleListener.cs" />
     <Compile Include="HtmlDocument.PathMethods.cs" />
@@ -80,6 +81,7 @@
     <Compile Include="HtmlNameTable.cs" />
     <Compile Include="HtmlNode.Xpath.cs" />
     <Compile Include="HtmlNodeCollection.cs" />
+    <Compile Include="HtmlNodeExtensions.cs" />
     <Compile Include="HtmlNodeType.cs" />
     <Compile Include="HtmlParseError.cs" />
     <Compile Include="HtmlParseErrorCode.cs" />

--- a/HtmlAgilityPack/HtmlAgilityPack.fx.4.0-CP.csproj
+++ b/HtmlAgilityPack/HtmlAgilityPack.fx.4.0-CP.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="EncodingFoundException.cs" />
     <Compile Include="HtmlAttributeCollection.cs" />
+    <Compile Include="HtmlAttributeExtensions.cs" />
     <Compile Include="HtmlCommentNode.cs" />
     <Compile Include="HtmlConsoleListener.cs" />
     <Compile Include="HtmlDocument.PathMethods.cs" />
@@ -80,6 +81,7 @@
     <Compile Include="HtmlNameTable.cs" />
     <Compile Include="HtmlNode.Xpath.cs" />
     <Compile Include="HtmlNodeCollection.cs" />
+    <Compile Include="HtmlNodeExtensions.cs" />
     <Compile Include="HtmlNodeType.cs" />
     <Compile Include="HtmlParseError.cs" />
     <Compile Include="HtmlParseErrorCode.cs" />

--- a/HtmlAgilityPack/HtmlAgilityPack.fx.4.0.csproj
+++ b/HtmlAgilityPack/HtmlAgilityPack.fx.4.0.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="EncodingFoundException.cs" />
     <Compile Include="HtmlAttributeCollection.cs" />
+    <Compile Include="HtmlAttributeExtensions.cs" />
     <Compile Include="HtmlCommentNode.cs" />
     <Compile Include="HtmlConsoleListener.cs" />
     <Compile Include="HtmlDocument.PathMethods.cs" />
@@ -80,6 +81,7 @@
     <Compile Include="HtmlNameTable.cs" />
     <Compile Include="HtmlNode.Xpath.cs" />
     <Compile Include="HtmlNodeCollection.cs" />
+    <Compile Include="HtmlNodeExtensions.cs" />
     <Compile Include="HtmlNodeType.cs" />
     <Compile Include="HtmlParseError.cs" />
     <Compile Include="HtmlParseErrorCode.cs" />

--- a/HtmlAgilityPack/HtmlAgilityPack.fx.4.5.csproj
+++ b/HtmlAgilityPack/HtmlAgilityPack.fx.4.5.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="EncodingFoundException.cs" />
     <Compile Include="HtmlAttributeCollection.cs" />
+    <Compile Include="HtmlAttributeExtensions.cs" />
     <Compile Include="HtmlCommentNode.cs" />
     <Compile Include="HtmlConsoleListener.cs" />
     <Compile Include="HtmlDocument.PathMethods.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="HtmlNameTable.cs" />
     <Compile Include="HtmlNode.Xpath.cs" />
     <Compile Include="HtmlNodeCollection.cs" />
+    <Compile Include="HtmlNodeExtensions.cs" />
     <Compile Include="HtmlNodeType.cs" />
     <Compile Include="HtmlParseError.cs" />
     <Compile Include="HtmlParseErrorCode.cs" />

--- a/HtmlAgilityPack/HtmlAttributeExtensions.cs
+++ b/HtmlAgilityPack/HtmlAttributeExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace HtmlAgilityPack
+{
+	public static class HtmlAttributeExtensions
+	{
+		public static int GetValueStartIndex(this HtmlAttribute attribute)
+		{
+			return attribute._valuestartindex;
+		}
+
+		public static int GetValueLength(this HtmlAttribute attribute)
+		{
+			return attribute._valuelength;
+		}
+	}
+}

--- a/HtmlAgilityPack/HtmlNodeExtensions.cs
+++ b/HtmlAgilityPack/HtmlNodeExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace HtmlAgilityPack
+{
+	public static class HtmlNodeExtensions
+	{
+		public static int GetInnerStartIndex(this HtmlNode node)
+		{
+			return node._innerstartindex;
+		}
+
+		public static int GetInnerLength(this HtmlNode node)
+		{
+			return node._innerlength;
+		}
+
+		public static int GetOuterStartIndex(this HtmlNode node)
+		{
+			return node._outerstartindex;
+		}
+
+		public static int GetOuterLength(this HtmlNode node)
+		{
+			return node._outerlength;
+		}
+
+		public static HtmlNode GetEndNode(this HtmlNode node)
+		{
+			return node._endnode;
+		}
+	}
+}


### PR DESCRIPTION
The content public properties `OuterHtml` and `InnerHtml` is optimized HTML where e.g.: all spaces between attributes are compacted into a single white-space. As a result we can't navigate in the HTML tree using a stream position.

For that reason we are expose the indexes calculated during the parse.
